### PR TITLE
Update route prop also on hash change

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -27,11 +27,24 @@ import './styles/main.pcss'
       <Init {...state} emitter={emitter} />,
       document.getElementById('root')
     )
+
+    document.querySelectorAll('.target').forEach(e => {
+      e.classList.remove('target')
+    })
+
+    const target = document.getElementById(window.location.hash.substr(1))
+    if (target) {
+      target.classList.add('target')
+      target.scrollIntoView()
+    }
+
     emitter.emit('setLoading', false)
+
   }
 
   document.addEventListener('DOMContentLoaded', () => {
 
+    const state = window.__APP_INITIAL_STATE__
     const api = new Api(window.__APP_INITIAL_STATE__.apiConfig)
 
     const emitter = mitt()
@@ -40,7 +53,6 @@ import './styles/main.pcss'
     // Save data to the API
     emitter.on('save', data => api.save(data)
       .then(response => {
-        const state = window.__APP_INITIAL_STATE__
         state.data = response.data
         state.user = response.user
         renderApp(state, emitter)
@@ -48,9 +60,11 @@ import './styles/main.pcss'
     )
     // Transition to a new URL
     emitter.on('navigate', url => {
-      if (window.location.pathname + window.location.search + window.location.hash !== url) {
+      const actualUrl = url.startsWith('#')
+        ? window.location.pathname + window.location.search + url
+        : ( url.startsWith('/') ? url : window.location.pathname + url)
+      if (window.location.pathname + window.location.search + window.location.hash !== actualUrl) {
         window.history.pushState(null, null, url)
-        window.dispatchEvent(new window.HashChangeEvent('hashchange'))
         window.dispatchEvent(new window.PopStateEvent('popstate'))
       }
     })
@@ -61,18 +75,6 @@ import './styles/main.pcss'
     // Log out of the API
     emitter.on('logout', () => api.logout())
 
-    window.addEventListener("hashchange", () => {
-      const hash = window.location.hash.substr(1)
-      document.querySelectorAll('.target').forEach(e => {
-        e.classList.remove('target')
-      })
-
-      const target = document.getElementById(hash)
-      if (target) {
-        target.classList.add('target')
-      }
-    })
-
     let current_url = window.location.pathname + window.location.search
     window.addEventListener('popstate', () => {
       const url = window.location.pathname + window.location.search
@@ -81,25 +83,17 @@ import './styles/main.pcss'
         emitter.emit('setLoading', true)
         api.load(url)
           .then(response => {
-            const state = window.__APP_INITIAL_STATE__
             state.data = response.data
             state.features = response.data.features || state.features
             state.user = response.user
             renderApp(state, emitter)
           })
+      } else {
+        renderApp(state, emitter)
       }
     })
 
     renderApp(window.__APP_INITIAL_STATE__, emitter)
 
-    const hash = window.location.hash.substr(1)
-    document.querySelectorAll('.target').forEach(e => {
-      e.classList.remove('target')
-    })
-
-    const target = document.getElementById(hash)
-    if (target) {
-      target.classList.add('target')
-    }
   })
 })()

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -11,13 +11,8 @@ class Link extends React.Component {
   }
 
   onClick(event) {
-
-    if (!this.props.to.startsWith('#')) {
-      event.preventDefault()
-      this.props.emitter.emit('navigate', this.getRef())
-    } else {
-      console.log("Link default behavior")
-    }
+    event.preventDefault()
+    this.props.emitter.emit('navigate', this.getRef())
   }
 
   getRef() {


### PR DESCRIPTION
So far we were bypassing `renderApp` and therefor also not updating the route props when triggering a URL change with a hash. In order to properly update the route passed down to the app, `renderApp` needs to be called on every URL change.