### PR TITLE
Route to resource after action

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -92,22 +92,40 @@ import Api from './api'
       window.location.reload()
     })
     // Form submission
-    emitter.on('submit', ({url, data}) => {
+    emitter.on('submit', ({url, data, redirect}) => {
       emitter.emit('setLoading', true)
       routes.route(url, context).post(data)
         .then(({title, data, render}) => {
-          state = data
-          window.history.pushState(null, null, data._location || url)
-          renderApp(title, render(data))
+          if (redirect) {
+            routes.route(redirect.url, context).get(redirect.params)
+              .then(({title, data, render}) => {
+                window.history.replaceState(null, null, redirect.url)
+                state = data
+                renderApp(title, render(data))
+              })
+          } else {
+            state = data
+            window.history.pushState(null, null, data._location || url)
+            renderApp(title, render(data))
+          }
         })
     })
     // Deletion
-    emitter.on('delete', ({url}) => {
+    emitter.on('delete', ({url, redirect}) => {
       routes.route(url, context).delete()
         .then(({title, data, render}) => {
-          state = data
-          window.history.pushState(null, null, url)
-          renderApp(title, render(data))
+          if (redirect) {
+            routes.route(redirect.url, context).get(redirect.params)
+              .then(({title, data, render}) => {
+                window.history.replaceState(null, null, redirect.url)
+                state = data
+                renderApp(title, render(data))
+              })
+          } else {
+            state = data
+            window.history.pushState(null, null, url)
+            renderApp(title, render(data))
+          }
         })
     })
 

--- a/src/components/Lighthouses.js
+++ b/src/components/Lighthouses.js
@@ -1,0 +1,61 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import ReactMarkdown from 'react-markdown'
+
+import Link from './Link'
+import withI18n from './withI18n'
+import withEmitter from './withEmitter'
+
+const Lighthouses = ({moment, translate, emitter, lighthouses, user, about}) => (
+  <div className="Lighthouses">
+
+    {lighthouses.filter(lighthouse => lighthouse.agent && lighthouse.description).map(lighthouse => (
+      <div className="Comment" key={lighthouse['@id']}>
+        <div className="head row auto">
+          <div className="col">
+            {lighthouse.agent.map(author => (
+              <Link key={author["@id"]} href={`/resource/${author["@id"]}`}>
+                {translate(author.name)}
+              </Link>)
+            )}{' '}
+            {moment(lighthouse.dateCreated).fromNow()}
+          </div>
+          {user &&
+          user.groups.includes('admin') &&
+            <div className="col">
+              <form onSubmit={(e) => {
+                e.preventDefault()
+                emitter.emit('delete', {
+                  url: `/resource/${lighthouse['@id']}`,
+                  redirect: {url: `/resource/${about['@id']}`}
+                })}}
+              >
+                <button className="btn icon" type="submit" title="Delete">
+                  <i className="fa fa-fw fa-trash" />
+                </button>
+              </form>
+            </div>
+          }
+        </div>
+        <ReactMarkdown source={translate(lighthouse.description)} />
+      </div>
+    ))}
+
+  </div>
+)
+
+Lighthouses.propTypes = {
+  moment: PropTypes.func.isRequired,
+  translate: PropTypes.func.isRequired,
+  emitter: PropTypes.objectOf(PropTypes.any).isRequired,
+  lighthouses: PropTypes.arrayOf(PropTypes.any),
+  user: PropTypes.objectOf(PropTypes.any),
+  about: PropTypes.objectOf(PropTypes.any).isRequired,
+}
+
+Lighthouses.defaultProps = {
+  lighthouses: [],
+  user: null,
+}
+
+export default withI18n(withEmitter(Lighthouses))

--- a/src/components/WebPageUserActions.js
+++ b/src/components/WebPageUserActions.js
@@ -62,11 +62,13 @@ const WebPageUserActions = ({user, about, emitter, view, translate}) => {
   const toggleLike = () => {
     if (like) {
       emitter.emit('delete', {
-        url: `/resource/${like['@id']}`
+        url: `/resource/${like['@id']}`,
+        redirect: { url: `/resource/${about['@id']}` }
       })
     } else {
       emitter.emit('submit', {
         url: '/resource/',
+        redirect: { url: `/resource/${about['@id']}` },
         data: {
           '@type': 'LikeAction',
           'object': about,
@@ -128,7 +130,11 @@ const WebPageUserActions = ({user, about, emitter, view, translate}) => {
           <Composer
             value={lighthouse}
             schema={schema}
-            submit={data => emitter.emit('submit', {url: `/resource/${lighthouse['@id'] || ''}`, data} )}
+            submit={data => emitter.emit('submit', {
+              url: `/resource/${lighthouse['@id'] || ''}`,
+              redirect: { url: `/resource/${about['@id']}` },
+              data
+            })}
             getOptions={(term, schema, callback) => emitter.emit('getOptions', {term, schema, callback})}
             getLabel={value => getLabel(translate, value)}
             submitLabel={translate('publish')}

--- a/src/components/WebPageView.js
+++ b/src/components/WebPageView.js
@@ -11,6 +11,7 @@ import WebPageUserActions from './WebPageUserActions'
 import SocialLinks from './SocialLinks'
 import Comments from './Comments'
 import Topline from './Topline'
+import Lighthouses from './Lighthouses'
 
 import { formatURL/*, obfuscate*/ } from '../common'
 import '../styles/components/WebPageView.pcss'
@@ -146,39 +147,15 @@ const WebPageView = ({translate, moment, about, user, view, expandAll}) => {
               </Block>
             }
 
-            {lighthouses &&
-              <Block className="lighthouseComments" title={translate('ResourceIndex.read.lighthouses.title')}>
-                {lighthouses.map(lighthouse => (
-                  <div className="Comment" key={lighthouse['@id']}>
-                    <div className="head row auto">
-                      <div className="col">
-                        {lighthouse.agent.map(author => (
-                          <Link key={author["@id"]} href={`/resource/${author["@id"]}`}>
-                            {translate(author.name)}
-                          </Link>)
-                        )}{' '}
-                        {moment(lighthouse.dateCreated).fromNow()}
-                      </div>
-                      {user &&
-                      user.groups.includes('admin') &&
-                        <div className="col">
-                          <form onSubmit={(e) => e.preventDefault() || console.warn("Delete lighthouse not implemented", e)}>
-                            <button className="btn icon" type="submit" title="Delete">
-                              <i className="fa fa-fw fa-trash" />
-                            </button>
-                          </form>
-                        </div>
-                      }
-                    </div>
-                    <ReactMarkdown source={translate(lighthouse.description)} />
-                  </div>
-                ))}
+            {lighthouses.length > 0 && about['@id'] &&
+              <Block title={translate('ResourceIndex.read.lighthouses.title')}>
+                <Lighthouses lighthouses={lighthouses} about={about} user={user} />
               </Block>
             }
 
             {about['@id'] &&
               <Block title={translate('ResourceIndex.read.comments')}>
-                <Comments comments={about['comment']} id={about['@id']} user={user} />
+                <Comments comments={about['comment']} about={about} user={user} />
               </Block>
             }
 


### PR DESCRIPTION
In some cases, such as when creating and deleting a `LikeAction` or a `LighthouseAction`, we don't want to go to the new URL, we want to stay on the current `WebPage`. For this, the `delete` and `submit` events now support a `redirect` parameter.