### PR TITLE
Add fix for truncated texts

### DIFF
--- a/src/styles/components/ItemList.pcss
+++ b/src/styles/components/ItemList.pcss
@@ -35,6 +35,7 @@
 
       & > span {
         flex: 1;
+        min-width: 0;
       }
     }
   }


### PR DESCRIPTION
Error caused  by this bug [Firefox: break-word doesn't work inside flex items](https://github.com/philipwalton/flexbugs/issues/39)

Using this solution to fix it.
[Flexbox and Truncated Text](https://css-tricks.com/flexbox-truncated-text/)