### PR TITLE
Remove displayName for WebPageview

### DIFF
--- a/src/components/WebPageView.js
+++ b/src/components/WebPageView.js
@@ -43,7 +43,7 @@ const WebPageView = ({translate, moment, about, user, view, expandAll, schema}) 
       </div>
 
       <h2>
-        {translate(about.displayName) || translate(about.name)}
+        {translate(about.name)}
         {about.alternateName &&
           <span className="alternate">
             &nbsp;({translate(about.alternateName)})


### PR DESCRIPTION
Related to https://github.com/hbz/oerworldmap/issues/1499.

**We still need to remove hide displayName in the Schema.**