### PR TITLE
Change question mark icon to user for CountryChampions without image

### DIFF
--- a/src/components/Country.js
+++ b/src/components/Country.js
@@ -100,7 +100,7 @@ class Country  extends React.Component {
               <div className={`countryChampionContainer ${this.state.showCountryChampion ? '' : 'collapsed'}`}>
                 <div className="user">
                   <div className="frame">
-                    <i className="fa fa-question" />
+                    <i className="fa fa-user" />
                   </div>
                   <div
                     className="text"


### PR DESCRIPTION
Fixes: hbz/oerworldmap#749

![image](https://user-images.githubusercontent.com/1938043/43580008-38a9964e-9654-11e8-9f8b-f34c2022a336.png)
