### PR TITLE
Don't merge original schema when expanding

### DIFF
--- a/src/components/JSONPointerForm/Builder.js
+++ b/src/components/JSONPointerForm/Builder.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import merge from 'deepmerge'
 
 import Fieldset from './Fieldset'
 import Input from './Input'
@@ -21,6 +22,10 @@ class Builder extends React.Component {
   }
 
   getComponent(schema) {
+
+    schema.allOf && (schema = merge.all(schema.allOf.concat(schema))) && (delete schema.allOf)
+    schema.anyOf && (schema = merge.all(schema.anyOf.concat(schema))) && (delete schema.anyOf)
+    schema.oneOf && (schema = merge.all(schema.oneOf.concat(schema))) && (delete schema.oneOf)
 
     const {translate, config} = this.props
     const widgets = Object.assign(

--- a/src/components/JSONPointerForm/JsonSchema.js
+++ b/src/components/JSONPointerForm/JsonSchema.js
@@ -15,16 +15,11 @@ const JsonSchema = (schema) => {
     if ('items' in schema) {
       schema.items = expandSchema(schema.items)
     }
-    if ('allOf' in schema) {
-      let schemas = {}
-      schema.allOf.forEach(allOf => schemas = merge(schemas, expandSchema(allOf)))
-      schema = merge(schemas, schema)
-      delete schema.allOf
-    }
-    if ('oneOf' in schema) {
-      schema = merge(schema, schema.oneOf.shift())
-      delete schema.oneOf
-    }
+    ['allOf', 'anyOf', 'oneOf'].forEach(property => {
+      if (property in schema) {
+        schema[property] = schema[property].map(subSchema => expandSchema(subSchema))
+      }
+    })
     if ('properties' in schema) {
       Object.keys(schema.properties).forEach((property) => {
         schema.properties[property] = expandSchema(


### PR DESCRIPTION
This is a first fix for https://github.com/hbz/oerworldmap/issues/1648. While the UI is still confusing because all fields from alternate schema `required`s are marked as required, it at least allows to save valid data again.