### PR TITLE
Add links to images in ResourceCover

### DIFF
--- a/src/components/ResourceImage.js
+++ b/src/components/ResourceImage.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import { getTwitterId } from '../common'
 import Icon from './Icon'
 import withI18n from './withI18n'
+import Link from './Link'
 
 import '../styles/components/ResourceImage.pcss'
 
@@ -11,8 +12,8 @@ const ResourceImage = ({about, translate, className}) => {
 
   const twitterId = getTwitterId(about.sameAs)
 
-  return (
-    <div className={`ResourceImage ${className}`}>
+  const images =
+    <React.Fragment>
       <div className="missingImg">
         <Icon type={about['@type']} />
       </div>
@@ -42,6 +43,19 @@ const ResourceImage = ({about, translate, className}) => {
           aria-label={translate(about.name)}
         />
       }
+    </React.Fragment>
+
+  return (
+    <div className={`ResourceImage ${className}`}>
+      {(about.url && className === 'webPageCoverImage') ? (
+        <a target="_blank" rel="noopener noreferrer" href={about.url}>
+          {images}
+        </a>
+      ) : (
+        <Link href={`/resource/${about["@id"]}`}>
+          {images}
+        </Link>
+      )}
     </div>
   )
 }

--- a/src/styles/components/WebPage.pcss
+++ b/src/styles/components/WebPage.pcss
@@ -80,16 +80,10 @@
       position: relative;
       height: 280px;
 
-      &:hover .ResourceImage {
-        opacity: 0;
-        transition: opacity 0.5s;
-      }
-
       & .ResourceImage {
         width: 200px;
         height: 200px;
         max-height: 200px;
-        pointer-events: none;
         transition: opacity 0.5s;
 
         & img {


### PR DESCRIPTION
Fixes: https://github.com/hbz/oerworldmap/issues/1483
Instead of hidding the image, now is a link to the url or to the resource itself if no link is provided.