### PR TITLE
Add OER Policy Registry link to header

### DIFF
--- a/docs/_data/locale/ui.json
+++ b/docs/_data/locale/ui.json
@@ -29,6 +29,7 @@
   "ClientTemplates.popoverCountry.champion": "Country Champion",
   "ClientTemplates.resource_typehead.search": "Search",
   "ClientTemplates.app.countryChampions": "Country Champions",
+  "ClientTemplates.app.oerpolicies": "OER Policy Registry",
   "CountryIndex.read.agreeConditions": "I agree to publish the information above under the conditions of <a href=\"/imprint#cc0\" target=\"_blank\">CC0-License</a>. I assure, that I have all rights necessary to publish the information to grant this license.",
   "CountryIndex.read.countryChampion": "Country Champion",
   "CountryIndex.read.noChampion": "There is no <a href=\"/contribute\">country champion</a> for %{country}, yet. <a href=\"mailto:info@oerworldmap.org\">Contact us</a> if you can jump in!",

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -138,6 +138,11 @@ class Header extends React.Component {
                           {this.props.translate('ClientTemplates.app.countryChampions')}
                         </Link>
                       </li>
+                      <li>
+                        <a className="item" href="/oerpolicies">
+                          {this.props.translate('ClientTemplates.app.oerpolicies')}
+                        </a>
+                      </li>
                     </ul>
 
                     {this.props.user &&


### PR DESCRIPTION
Fixes: https://github.com/hbz/oerworldmap/issues/1684
It would be perfect if we find an Icon for this new link, right now it looks like this.
![image](https://user-images.githubusercontent.com/1938043/47159879-0e13de80-d2ef-11e8-84d3-2cc075499217.png)
