### PR TITLE
Add possiblity to close modals with a click outside the dialog

### DIFF
--- a/src/components/FullModal.js
+++ b/src/components/FullModal.js
@@ -1,12 +1,23 @@
+/* global document */
 import React from 'react'
 import PropTypes from 'prop-types'
 
 import Link from './Link'
+import withEmitter from './withEmitter'
 
 import '../styles/components/FullModal.pcss'
 
-const FullModal = ({className, children, closeLink}) => (
-  <div className={`FullModal ${className || ''}`}>
+const FullModal = ({className, children, closeLink, emitter}) => (
+  <div
+    className={`FullModal ${className || ''}`}
+    role="presentation"
+    onClick={(e) => {
+      const modalDialog = document.querySelector('.modalDialog')
+      if (!modalDialog.contains(e.target)) {
+        emitter.emit('navigate', Link.home)
+      }
+    }}
+  >
     <div className="modalDialog">
       {children}
       <Link href={closeLink || Link.home} className="closeModal">
@@ -19,7 +30,8 @@ const FullModal = ({className, children, closeLink}) => (
 FullModal.propTypes = {
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
-  closeLink: PropTypes.string
+  closeLink: PropTypes.string,
+  emitter: PropTypes.objectOf(PropTypes.any).isRequired,
 }
 
 FullModal.defaultProps = {
@@ -27,4 +39,4 @@ FullModal.defaultProps = {
   closeLink: null
 }
 
-export default FullModal
+export default withEmitter(FullModal)

--- a/src/components/WebPage.js
+++ b/src/components/WebPage.js
@@ -1,3 +1,5 @@
+/* global document */
+/* global confirm */
 import React from 'react'
 import PropTypes from 'prop-types'
 
@@ -7,6 +9,9 @@ import WebPageHeader from './WebPageHeader'
 import WebPageCover from './WebPageCover'
 
 import expose from '../expose'
+import withEmitter from './withEmitter'
+import withI18n from './withI18n'
+import Link from './Link'
 
 import '../styles/components/WebPage.pcss'
 import '../styles/components/FormStyle.pcss'
@@ -23,10 +28,25 @@ const WebPage = ({
   mapboxConfig,
   schema,
   embedValue,
-  showOptionalFields
+  showOptionalFields,
+  emitter,
+  translate
 }) => {
   return (
-    <div className="webPageWrapper">
+    <div
+      className="webPageWrapper"
+      role="presentation"
+      onClick={e => {
+        const modalDialog = document.querySelector('.WebPage')
+        if (!modalDialog.contains(e.target)) {
+          if (view === "edit") {
+            confirm(translate("Do you want to go leave the edit view?")) && emitter.emit('navigate', _self || Link.home)
+          } else {
+            emitter.emit('navigate', Link.home)
+          }
+        }
+      }}
+    >
       <div className="WebPage">
 
         <WebPageHeader
@@ -86,7 +106,9 @@ WebPage.propTypes = {
   ).isRequired,
   schema: PropTypes.objectOf(PropTypes.any).isRequired,
   embedValue: PropTypes.string,
-  showOptionalFields: PropTypes.bool
+  showOptionalFields: PropTypes.bool,
+  emitter: PropTypes.objectOf(PropTypes.any).isRequired,
+  translate: PropTypes.func.isRequired
 }
 
 WebPage.defaultProps = {
@@ -99,4 +121,4 @@ WebPage.defaultProps = {
   showOptionalFields: true
 }
 
-export default WebPage
+export default withEmitter(withI18n(WebPage))


### PR DESCRIPTION
Fixes: https://github.com/hbz/oerworldmap/issues/1521
Now is possible to go back by clicking on the empty wrapper of a modal, and in edit view the user will be prompt to go back.
Refactor to not use querySelector when we can create refs with React hocks.