### PR TITLE
Add encodeURIComponent to keywords links

### DIFF
--- a/src/components/Topline.js
+++ b/src/components/Topline.js
@@ -201,7 +201,7 @@ const Topline = ({translate, moment, about, className}) => {
             <ul className="spaceSeparatedList">
               {about.keywords.sort((a,b) => a > b).map(keyword => (
                 <li key={keyword}>
-                  <Link href={`/resource/?filter.about.keywords=${keyword.toLowerCase()}`}>
+                  <Link href={`/resource/?filter.about.keywords=${encodeURIComponent(keyword.toLowerCase())}`}>
                     {keyword}
                   </Link>
                 </li>

--- a/src/components/WebPageView.js
+++ b/src/components/WebPageView.js
@@ -263,7 +263,7 @@ const WebPageView = ({translate, moment, about, user, view, expandAll, schema}) 
                 <ul className="spaceSeparatedList">
                   {about.keywords.sort((a,b) => a > b).map(keyword => (
                     <li key={keyword}>
-                      <Link href={`/resource/?filter.about.keywords=${keyword.toLowerCase()}`}>
+                      <Link href={`/resource/?filter.about.keywords=${encodeURIComponent(keyword.toLowerCase())}`}>
                         {keyword}
                       </Link>
                     </li>


### PR DESCRIPTION
Fixes: https://github.com/hbz/oerworldmap/issues/1743
![encode](https://user-images.githubusercontent.com/1938043/55874427-a601cf00-5b92-11e9-9e11-fb8520dc630c.gif)
