### PR TITLE
Import only the fonts we use

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import 'font-awesome/css/font-awesome.css'
-import 'source-sans-pro/source-sans-pro.css'
+import '../styles/fonts.pcss'
 import 'rc-tooltip/assets/bootstrap_white.css'
 import Header from './Header'
 import Loading from './Loading'

--- a/src/styles/fonts.pcss
+++ b/src/styles/fonts.pcss
@@ -1,0 +1,65 @@
+@font-face{
+    font-family: 'Source Sans Pro';
+    font-weight: 400;
+    font-style: normal;
+    font-stretch: normal;
+    src: url('../../node_modules/source-sans-pro/WOFF2/TTF/SourceSansPro-Regular.ttf.woff2') format('woff2'),
+         url('../../node_modules/source-sans-pro/WOFF/OTF/SourceSansPro-Regular.otf.woff') format('woff'),
+         url('../../node_modules/source-sans-pro/OTF/SourceSansPro-Regular.otf') format('opentype'),
+         url('../../node_modules/source-sans-pro/TTF/SourceSansPro-Regular.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Sans Pro';
+    font-weight: 400;
+    font-style: italic;
+    font-stretch: normal;
+    src: url('../../node_modules/source-sans-pro/WOFF2/TTF/SourceSansPro-It.ttf.woff2') format('woff2'),
+         url('../../node_modules/source-sans-pro/WOFF/OTF/SourceSansPro-It.otf.woff') format('woff'),
+         url('../../node_modules/source-sans-pro/OTF/SourceSansPro-It.otf') format('opentype'),
+         url('../../node_modules/source-sans-pro/TTF/SourceSansPro-It.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Sans Pro';
+    font-weight: 600;
+    font-style: normal;
+    font-stretch: normal;
+    src: url('../../node_modules/source-sans-pro/WOFF2/TTF/SourceSansPro-Semibold.ttf.woff2') format('woff2'),
+         url('../../node_modules/source-sans-pro/WOFF/OTF/SourceSansPro-Semibold.otf.woff') format('woff'),
+         url('../../node_modules/source-sans-pro/OTF/SourceSansPro-Semibold.otf') format('opentype'),
+         url('../../node_modules/source-sans-pro/TTF/SourceSansPro-Semibold.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Sans Pro';
+    font-weight: 600;
+    font-style: italic;
+    font-stretch: normal;
+    src: url('../../node_modules/source-sans-pro/WOFF2/TTF/SourceSansPro-SemiboldIt.ttf.woff2') format('woff2'),
+         url('../../node_modules/source-sans-pro/WOFF/OTF/SourceSansPro-SemiboldIt.otf.woff') format('woff'),
+         url('../../node_modules/source-sans-pro/OTF/SourceSansPro-SemiboldIt.otf') format('opentype'),
+         url('../../node_modules/source-sans-pro/TTF/SourceSansPro-SemiboldIt.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Sans Pro';
+    font-weight: 700;
+    font-style: normal;
+    font-stretch: normal;
+    src: url('../../node_modules/source-sans-pro/WOFF2/TTF/SourceSansPro-Bold.ttf.woff2') format('woff2'),
+         url('../../node_modules/source-sans-pro/WOFF/OTF/SourceSansPro-Bold.otf.woff') format('woff'),
+         url('../../node_modules/source-sans-pro/OTF/SourceSansPro-Bold.otf') format('opentype'),
+         url('../../node_modules/source-sans-pro/TTF/SourceSansPro-Bold.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Sans Pro';
+    font-weight: 700;
+    font-style: italic;
+    font-stretch: normal;
+    src: url('../../node_modules/source-sans-pro/WOFF2/TTF/SourceSansPro-BoldIt.ttf.woff2') format('woff2'),
+         url('../../node_modules/source-sans-pro/WOFF/OTF/SourceSansPro-BoldIt.otf.woff') format('woff'),
+         url('../../node_modules/source-sans-pro/OTF/SourceSansPro-BoldIt.otf') format('opentype'),
+         url('../../node_modules/source-sans-pro/TTF/SourceSansPro-BoldIt.ttf') format('truetype');
+}


### PR DESCRIPTION
By importing only the fonts we use, the size of **dist** is reduced from `10,6 MB` to `7,5 MB`.