### PR TITLE
Remove http and https from user images

### DIFF
--- a/src/components/ResourceImage.js
+++ b/src/components/ResourceImage.js
@@ -23,7 +23,7 @@ const ResourceImage = ({
       {about.image && (
         <img
           className={about['@type']}
-          src={about.image}
+          src={about.image.replace('http:', '').replace('https:', '')}
           alt={translate(about.name)}
           style={{
             visibility: 'hidden',


### PR DESCRIPTION
Fixes: https://github.com/hbz/oerworldmap/issues/1880
With this branch we expect users to input images always under https,