### PR TITLE
Make the content scrollable for small screens

### DIFF
--- a/src/styles/components/Columns.pcss
+++ b/src/styles/components/Columns.pcss
@@ -206,3 +206,14 @@
     }
   }
 }
+
+@media screen and (--mobile-breakpoint) {
+  .__floater__body {
+    max-height: 100vh;
+    overflow: scroll;
+
+    & .react-joyride__tooltip {
+      width: 100vw;
+    }
+  }
+}


### PR DESCRIPTION
Fixes: https://github.com/hbz/oerworldmap/issues/1888
![photo5886620187090858500](https://user-images.githubusercontent.com/1938043/67676831-b046b780-f982-11e9-95f5-fbe26316e33e.jpg)

The content can be scrolled to continue the tour.