### PR TITLE
Fix padding for Live Event

### DIFF
--- a/src/styles/components/WebPageView.pcss
+++ b/src/styles/components/WebPageView.pcss
@@ -8,7 +8,7 @@
   }
 
   & .isLiveEvent {
-    margin-top: -20px;
+    margin-top: 20px;
     margin-bottom: 20px;
 
     & a {


### PR DESCRIPTION
Fixes: https://github.com/hbz/oerworldmap/issues/1904
The padding was supposed to be 20 not -20
![image](https://user-images.githubusercontent.com/1938043/69355038-6e5b1980-0c81-11ea-888b-6901a4d31137.png)
