### PR TITLE
Don't render email address in server-side html to prevent scraping

### DIFF
--- a/src/components/WebPageView.js
+++ b/src/components/WebPageView.js
@@ -723,12 +723,7 @@ const WebPageView = ({
           {about.email && !isNode() && (
             <Block title={translate(`${about['@type']}.email`)}>
               <p>
-                <a
-                  href={`mailto:${Buffer ? Buffer.from(about.email).toString('base64') : btoa(about.email)}`}
-                  onClick={(e) => {
-                    e.target.href = `mailto:${about.email}`
-                  }}
-                >
+                <a href={`mailto:${about.email}`}>
                   {about.email}
                 </a>
               </p>

--- a/src/components/WebPageView.js
+++ b/src/components/WebPageView.js
@@ -22,7 +22,7 @@ import Topline from './Topline'
 import Lighthouses from './Lighthouses'
 import LinkOverride from './LinkOverride'
 
-import { formatURL, formatDate } from '../common'
+import { formatURL, formatDate, isNode } from '../common'
 import centroids from '../json/centroids.json'
 import expose from '../expose'
 import '../styles/components/WebPageView.pcss'
@@ -720,7 +720,7 @@ const WebPageView = ({
             </Block>
           )}
 
-          {about.email && (
+          {about.email && !isNode() && (
             <Block title={translate(`${about['@type']}.email`)}>
               <p>
                 <a

--- a/src/components/WebPageView.js
+++ b/src/components/WebPageView.js
@@ -1,4 +1,3 @@
-/* global btoa */
 import React from 'react'
 import PropTypes from 'prop-types'
 import Markdown from 'markdown-to-jsx'


### PR DESCRIPTION
This code adds a check if it's rendered for search engines/crawlers or if it's run in the browser. If it's run in the browser, then it displays e-mail section. It's not 100% optimal, but it's much more resource intensive on scrapers. At the end of the day, if we show this data to (non-logged in) visitor, then we can't hide it from a very resourcesful scraper. 

Ref: https://github.com/hbz/oerworldmap/issues/1936