### PR TITLE
Updates 'Call for tender' value

### DIFF
--- a/src/json/policyTypes.json
+++ b/src/json/policyTypes.json
@@ -63,7 +63,7 @@
       "name": [
         {
           "@language": "en",
-          "@value": "Call for tender"
+          "@value": "Call for tender/proposal"
         },
         {
           "@language": "pt",
@@ -71,7 +71,7 @@
         },
         {
           "@language": "de",
-          "@value": "Call for tender"
+          "@value": "Call for tender/proposal"
         }
       ]
     },

--- a/src/json/policyTypes.json
+++ b/src/json/policyTypes.json
@@ -63,7 +63,7 @@
       "name": [
         {
           "@language": "en",
-          "@value": "Call for tender/proposal"
+          "@value": "Call for proposals/tenders/grants"
         },
         {
           "@language": "pt",
@@ -71,7 +71,7 @@
         },
         {
           "@language": "de",
-          "@value": "Call for tender/proposal"
+          "@value": "Ausschreibungen und Förderlinien"
         }
       ]
     },


### PR DESCRIPTION
This PR updates "Call for tender" to be "Call for tender/proposal". It's rebased from https://github.com/hbz/oerworldmap-ui/pull/629 .

To deploy, from `oerworldmap-ui ` (please change `http://localhost:9000` to correct API location)

```
curl -H "Content-type: application/json" http://localhost:9000/import/ -d @src/json/policyTypes.json
```

Ref: https://github.com/hbz/oerworldmap/issues/1937