### PR TITLE
Dev improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "The user interface for https://oerworldmap.org/",
   "scripts": {
     "clean": "rimraf dist/",
-    "build:dev": "NODE_ENV=development webpack-cli -w",
+    "build:dev": "NODE_ENV=development webpack-cli -w --watch-poll",
     "build:prod": "NODE_ENV=production webpack-cli",
-    "server:dev": "NODE_ENV=development nodemon -w dev dev/server.js",
+    "server:dev": "NODE_ENV=development nodemon -w dev dev/server.js --watch-poll",
     "server:prod": "NODE_ENV=production node dist/server.js",
     "test": "eslint src --quiet && jest",
     "singleTest": "node --inspect-brk  node_modules/.bin/jest --verbose=false --runInBand -t ",

--- a/src/api.js
+++ b/src/api.js
@@ -18,7 +18,7 @@ const checkStatus = (response) => {
   if (response.status >= 200 && response.status < 300) {
     return Promise.resolve(response)
   }
-  return Promise.reject(new APIError(response.statusText, response.status))
+  return Promise.reject(new APIError(`${response.url} returned ${response.statusText}`, response.status))
 }
 
 const toJson = response => response.json().then((json) => {


### PR DESCRIPTION
- Adds `--watch-poll` to webapack-cli so that code reloading works inside vagrant
- Improves APIError logger 

Previously logged displayed errors like this:
`APIError { name: 'APIError', message: 'Not Found', status: 404 }`

and with this change, it reports as:

```
APIError {
  name: 'APIError',
  message: 'http://oerworldmap.test:80/label returned Not Found',
  status: 404 }
```

So it's clearer which request failed

Ref: https://github.com/hbz/oerworldmap/issues/1952