### PR TITLE
Fixes crash in /activity if comment text is missing

### DIFF
--- a/src/components/TimelineBlock.js
+++ b/src/components/TimelineBlock.js
@@ -80,7 +80,7 @@ const TimelineBlock = ({
         <div className={`timelineBlockContent${withBorder ? ' withBorder' : ''}`}>
           <ResourcePreview about={resource} />
 
-          {entry.about['@type'] === 'Comment' && (
+          {entry.about['@type'] === 'Comment' && entry.about.text && (
             <div className="comment">
               <div className="commentMetadata">
                 <Link href={user['@id']}>{translate(user.name)}</Link>


### PR DESCRIPTION
Markdown parser in activty stream crashes if there is no comment field. As far as I can see, this happens when entry is deleted and there's a previous comment in the activity stream that is not there anymore.

This PR is just a simple check so we don't try to render invalid component.

Ref: https://github.com/hbz/oerworldmap/issues/1951