### PR TITLE
docs: fix layout in Portuguese FAQ

### DIFF
--- a/docs/FAQ.pt.md
+++ b/docs/FAQ.pt.md
@@ -1,6 +1,6 @@
 ---
 title: FAQ
-layout: página
+layout: page
 class: faq
 ---
 


### PR DESCRIPTION
the layout name 'page' was translated to portuguese, but should, leading to a warning and wrong layout