### PR TITLE
docs: use working jekyll docker image tag

### DIFF
--- a/docs/docker-compose.yml
+++ b/docs/docker-compose.yml
@@ -1,5 +1,5 @@
 jekyll:
-    image: jekyll/jekyll:pages
+    image: jekyll/jekyll:3.7.0
     command: jekyll serve --watch --incremental
     ports:
         - 4000:4000


### PR DESCRIPTION
the latest tag 'pages' is incompatible with the content, use the image tag that was the current one when the docker-compose was created

otherwise it led to this error:
```
jekyll_1  |   Conversion error: Jekyll::Converters::Scss encountered an error while converting 'assets/css/style.scss':
jekyll_1  |                     File to import not found or unreadable: jekyll-theme-primer. Load path: /usr/gem/gems/jekyll-theme-primer-0.6.0/_sass on line 1
```